### PR TITLE
Add `npm run fix` for automatically fixing eslint errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/**
 lib/**
+dist/**

--- a/build/tasks/task-start.js
+++ b/build/tasks/task-start.js
@@ -36,14 +36,14 @@ gulp.task('start', async () => {
       spawn('node', Paths.QBRT_RUNNER_DST_MAIN, runnerArgs, { logger }),
       spawn('node', Paths.BROWSER_SERVER_DST_MAIN, args, { logger }),
     ]);
-  } else {
-    const electron = process.platform === 'win32'
-      ? 'electron.cmd'
-      : 'electron';
-
-    return Promise.all([
-      spawn(electron, Paths.ELECTRON_RUNNER_DST_MAIN, runnerArgs, { logger }),
-      spawn('node', Paths.BROWSER_SERVER_DST_MAIN, args, { logger }),
-    ]);
   }
+
+  const electron = process.platform === 'win32'
+    ? 'electron.cmd'
+    : 'electron';
+
+  return Promise.all([
+    spawn(electron, Paths.ELECTRON_RUNNER_DST_MAIN, runnerArgs, { logger }),
+    spawn('node', Paths.BROWSER_SERVER_DST_MAIN, args, { logger }),
+  ]);
 });

--- a/build/tasks/task-test.js
+++ b/build/tasks/task-test.js
@@ -22,14 +22,14 @@ gulp.task('eslint', () => {
   const ignorePath = path.join(Paths.ROOT_DIR, '.eslintignore');
   const ignoreGlobs = fs.readFileSync(ignorePath, { encoding: 'utf8' });
   const glob = [
-    `${Paths.SRC_DIR}/**/*.@(js|jsx)`,
+    `${Paths.ROOT_DIR}/**/*.@(js|jsx)`,
     ...ignoreGlobs.trim().split('\n').map(i => `!${i}`),
   ];
   return gulp.src(glob)
     .pipe(debug({ title: `Running ${colors.cyan(`eslint${yargs.argv.fix ? ' --fix' : ''}`)}:` }))
-    .pipe(eslint())
+    .pipe(eslint({ fix: yargs.argv.fix }))
     .pipe(eslint.format())
-    .pipe(gulpif(f => f.eslint != null && f.eslint.fixed, gulp.dest(Paths.SRC_DIR)))
+    .pipe(gulpif(f => f.eslint != null && f.eslint.fixed, gulp.dest(Paths.ROOT_DIR)))
     .pipe(eslint.failAfterError());
 });
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "gulp test",
+    "fix": "gulp eslint --fix",
     "clean": "gulp clean",
     "start": "cross-env NODE_ENV=production gulp build+start --obj-dir-name production-electron",
     "serve": "cross-env NODE_ENV=development gulp build+serve --obj-dir-name development-headless",


### PR DESCRIPTION
This was supposed to work ages ago, but has since regressed like crazy since I totally forgot about it.