### PR TITLE
feature: open webpage in new window

### DIFF
--- a/src/browser-frontend/reducers/pages-reducers.js
+++ b/src/browser-frontend/reducers/pages-reducers.js
@@ -19,7 +19,7 @@ import PagesModelActions from '../actions/pages-model-actions';
 import DomainPageModel from '../model/domain-page-model';
 import UIPageModel from '../model/ui-page-model';
 
-function addPage(state, { payload: { url, index, background } = {} }) {
+function addPage(state, { payload: { url, parentId, background } = {} }) {
   return state.withMutations((mut) => {
     const pageId = uuid();
     const pageUrl = url || Endpoints.DEFAULT_PAGE_URL;
@@ -32,7 +32,7 @@ function addPage(state, { payload: { url, index, background } = {} }) {
     mut.updateIn(['ui', 'pages', 'visuals'], m => m.set(pageId, pageUIState));
 
     const pageCount = state.ui.pages.displayOrder.count();
-    const pageIndex = index != null ? index : pageCount;
+    const pageIndex = parentId ? state.ui.pages.displayOrder.findIndex(id => id === parentId) + 1 : pageCount;
     mut.updateIn(['ui', 'pages', 'displayOrder'], l => l.insert(pageIndex, pageId));
 
     if (!background) {

--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -95,7 +95,7 @@ function* onPageDidNavigateInternal() {
 }
 
 function* onPageDidNavigateToNewWindow({ payload: { parentId, url } }) {
-  yield put(PagesModelActions.addPage({ parentId, url }));
+  yield put(PagesModelActions.addPage({ parentId, url, background: false }));
 }
 
 export default function* () {

--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -94,8 +94,8 @@ function* onPageDidNavigateInternal() {
   // TODO
 }
 
-function* onPageDidNavigateToNewWindow({ payload: { pageId, url } }) {
-  yield put(PagesModelActions.addPage({ url, pageId }));
+function* onPageDidNavigateToNewWindow({ payload: { parentId, url } }) {
+  yield put(PagesModelActions.addPage({ parentId, url }));
 }
 
 export default function* () {

--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -94,8 +94,8 @@ function* onPageDidNavigateInternal() {
   // TODO
 }
 
-function* onPageDidNavigateToNewWindow() {
-  // TODO
+function* onPageDidNavigateToNewWindow({ payload: { pageId, url } }) {
+  yield put(PagesModelActions.addPage({ url, pageId }));
 }
 
 export default function* () {

--- a/src/browser-frontend/views/browser/chrome/page.jsx
+++ b/src/browser-frontend/views/browser/chrome/page.jsx
@@ -74,8 +74,8 @@ export default class Page extends PureComponent {
     this.props.dispatch(WebContentsActions.events.pageDidNavigateInternal({ pageId: this.props.pageId }));
   }
 
-  handleDidNavigateToNewWindow = () => {
-    this.props.dispatch(WebContentsActions.events.pageDidNavigateToNewWindow({ pageId: this.props.pageId }));
+  handleDidNavigateToNewWindow = ({ url }) => {
+    this.props.dispatch(WebContentsActions.events.pageDidNavigateToNewWindow({ pageId: this.props.pageId, url }));
   }
 
   render() {

--- a/src/browser-frontend/views/browser/chrome/page.jsx
+++ b/src/browser-frontend/views/browser/chrome/page.jsx
@@ -75,7 +75,7 @@ export default class Page extends PureComponent {
   }
 
   handleDidNavigateToNewWindow = ({ url }) => {
-    this.props.dispatch(WebContentsActions.events.pageDidNavigateToNewWindow({ pageId: this.props.pageId, url }));
+    this.props.dispatch(WebContentsActions.events.pageDidNavigateToNewWindow({ parentId: this.props.pageId, url }));
   }
 
   render() {

--- a/src/shared/widgets/web-contents/webview.jsx
+++ b/src/shared/widgets/web-contents/webview.jsx
@@ -44,8 +44,8 @@ export default class WebView extends PureComponent {
     this._webview.addEventListener('did-navigate-in-page', () => {
       this.props.onDidNavigateInternal();
     });
-    this._webview.addEventListener('new-window', () => {
-      this.props.onDidNavigateToNewWindow();
+    this._webview.addEventListener('new-window', (e) => {
+      this.props.onDidNavigateToNewWindow({ url: e.url });
     });
   }
 


### PR DESCRIPTION
open for visibility

tested with mac - `cmd-click` opens page in new tab.
Only works when running on electron.

TODO: 
- ~~ensure the tab opens beside the parent tab.~~
- should it open in the background or foreground? ( I need to be able to test with foreground opening for the desired animation, my understanding is that this can generally be user-set)
