### PR TITLE
Make sourcemaps work again

### DIFF
--- a/build/webpack/config.base.js
+++ b/build/webpack/config.base.js
@@ -11,9 +11,9 @@ export default {
       test: /\.jsx?$/,
       exclude: /node_modules/,
       use: [{
-        loader: 'webpack-module-hot-accept',
-      }, {
         loader: 'babel-loader',
+      }, {
+        loader: 'webpack-module-hot-accept',
       }],
     }, {
       test: /\.css$/,


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

Apparently babel needs to be the first parser in the webpack config for sourcemaps to work. TIL!