### PR TITLE
Fix the Windows packaged build.

### DIFF
--- a/src/shared/util/spawn.js
+++ b/src/shared/util/spawn.js
@@ -13,6 +13,7 @@ specific language governing permissions and limitations under the License.
 import cp from 'child_process';
 
 import colors from 'colour';
+import { IS_PACKAGED_BUILD } from '../build-info';
 
 export const spawn = (command, main, args, { logger }, options = {}) => new Promise((resolve, reject) => {
   logger.log('Spawning',
@@ -20,7 +21,10 @@ export const spawn = (command, main, args, { logger }, options = {}) => new Prom
     colors.blue(main),
     colors.yellow(args.join(' ')));
 
-  const child = cp.spawn(command, [main, ...args], { stdio: 'inherit', ...options });
+  const stdio = process.platform === 'win32' && IS_PACKAGED_BUILD
+    ? 'ignore'
+    : 'inherit';
+  const child = cp.spawn(command, [main, ...args], { stdio, ...options });
   child.on('error', reject);
   child.on('exit', resolve);
 


### PR DESCRIPTION
Fixes https://github.com/victorporof/tofino/issues/34

The problem was that io doesn’t let us spawn child processes on Windows with the same stdio, as per [this comment](https://github.com/electron/electron/issues/1613#issuecomment-101446164), so let’s just ignore it in that specific case.