### PR TITLE
feature: Slide new tab in from left if it has a parent tab

### DIFF
--- a/src/browser-frontend/actions/pages-model-actions.js
+++ b/src/browser-frontend/actions/pages-model-actions.js
@@ -27,6 +27,7 @@ export default createActions({
   TABBAR: {
     SET_TAB_STATE: identity,
     CLOSE_TAB_ANIMATED: identity,
+    CHANGE_OPTIONAL_CLASS: identity,
   },
   NAVBAR: {
     SET_LOCATION_INPUT_BAR_VALUE: identity,

--- a/src/browser-frontend/actions/pages-model-actions.js
+++ b/src/browser-frontend/actions/pages-model-actions.js
@@ -27,7 +27,7 @@ export default createActions({
   TABBAR: {
     SET_TAB_STATE: identity,
     CLOSE_TAB_ANIMATED: identity,
-    CHANGE_OPTIONAL_CLASS: identity,
+    CHANGE_OPTIONAL_TAB_CLASS: identity,
   },
   NAVBAR: {
     SET_LOCATION_INPUT_BAR_VALUE: identity,

--- a/src/browser-frontend/css/theme.css
+++ b/src/browser-frontend/css/theme.css
@@ -51,6 +51,7 @@
   /* Tabbar */
 
   --theme-tabbar-height: 40px;
+  --theme-tabbar-top-padding: 10px;
   --theme-tabbar-background: transparent;
   --theme-new-tab-button-image: url('../assets/New - 16.svg');
   --theme-new-tab-button-background: transparent;

--- a/src/browser-frontend/model/domain-page-meta-model.js
+++ b/src/browser-frontend/model/domain-page-meta-model.js
@@ -28,6 +28,7 @@ const DomainPageMetaModel = Immutable.Record({
   title: UNKNOWN_TITLE,
   favicon: UNKNOWN_FAVICON,
   bookmarked: false,
+  tabOwner: null,
 });
 
 DomainPageMetaModel.UNKNOWN_TITLE = UNKNOWN_TITLE;

--- a/src/browser-frontend/model/ui-page-model.js
+++ b/src/browser-frontend/model/ui-page-model.js
@@ -22,7 +22,6 @@ const TAB_STATES = {
 const UIPageModel = Immutable.Record({
   tabState: TAB_STATES.INITIAL,
   locationInputBarValue: '',
-  tabOwner: '',
   optionalClass: '',
 });
 

--- a/src/browser-frontend/model/ui-page-model.js
+++ b/src/browser-frontend/model/ui-page-model.js
@@ -23,6 +23,7 @@ const UIPageModel = Immutable.Record({
   tabState: TAB_STATES.INITIAL,
   locationInputBarValue: '',
   tabOwner: '',
+  optionalClass: '',
 });
 
 UIPageModel.TAB_STATES = TAB_STATES;

--- a/src/browser-frontend/model/ui-page-model.js
+++ b/src/browser-frontend/model/ui-page-model.js
@@ -22,6 +22,7 @@ const TAB_STATES = {
 const UIPageModel = Immutable.Record({
   tabState: TAB_STATES.INITIAL,
   locationInputBarValue: '',
+  tabOwner: '',
 });
 
 UIPageModel.TAB_STATES = TAB_STATES;

--- a/src/browser-frontend/reducers/pages-reducers.js
+++ b/src/browser-frontend/reducers/pages-reducers.js
@@ -28,10 +28,10 @@ function addPage(state, { payload: { url, parentId, background } = {} }) {
     const pageDomainState = new DomainPageModel({ id: pageId, url: pageUrl });
     const pageUIState = new UIPageModel({
       locationInputBarValue: pageUrl,
-      tabOwner,
     });
     mut.updateIn(['domain', 'pages'], m => m.set(pageId, pageDomainState));
     mut.updateIn(['ui', 'pages', 'visuals'], m => m.set(pageId, pageUIState));
+    mut.setIn(['domain', 'pages', pageId, 'meta', 'tabOwner'], tabOwner);
 
     const pageCount = state.ui.pages.displayOrder.count();
     const pageIndex = parentId ? state.ui.pages.displayOrder.findIndex(id => id === parentId) + 1 : pageCount;

--- a/src/browser-frontend/reducers/pages-reducers.js
+++ b/src/browser-frontend/reducers/pages-reducers.js
@@ -24,9 +24,11 @@ function addPage(state, { payload: { url, parentId, background } = {} }) {
     const pageId = uuid();
     const pageUrl = url || Endpoints.DEFAULT_PAGE_URL;
 
+    const tabOwner = parentId || '';
     const pageDomainState = new DomainPageModel({ id: pageId, url: pageUrl });
     const pageUIState = new UIPageModel({
       locationInputBarValue: pageUrl,
+      tabOwner,
     });
     mut.updateIn(['domain', 'pages'], m => m.set(pageId, pageDomainState));
     mut.updateIn(['ui', 'pages', 'visuals'], m => m.set(pageId, pageUIState));

--- a/src/browser-frontend/reducers/pages-reducers.js
+++ b/src/browser-frontend/reducers/pages-reducers.js
@@ -24,7 +24,7 @@ function addPage(state, { payload: { url, parentId, background } = {} }) {
     const pageId = uuid();
     const pageUrl = url || Endpoints.DEFAULT_PAGE_URL;
 
-    const tabOwner = parentId || '';
+    const tabOwner = parentId;
     const pageDomainState = new DomainPageModel({ id: pageId, url: pageUrl });
     const pageUIState = new UIPageModel({
       locationInputBarValue: pageUrl,

--- a/src/browser-frontend/reducers/pages-tabbar-reducers.js
+++ b/src/browser-frontend/reducers/pages-tabbar-reducers.js
@@ -19,11 +19,11 @@ function setTabState(state, { payload: { pageId, tabState } }) {
   return state.setIn(['ui', 'pages', 'visuals', pageId, 'tabState'], tabState);
 }
 
-function changeOptionalClass(state, { payload: { parentId, optionalClass } }) {
-  return state.setIn(['ui', 'pages', 'visuals', parentId, 'optionalClass'], optionalClass);
+function changeOptionalTabClass(state, { payload: { pageId, optionalClass } }) {
+  return state.setIn(['ui', 'pages', 'visuals', pageId, 'optionalClass'], optionalClass);
 }
 
 export default handleActions({
   [PagesModelActions.tabbar.setTabState]: setTabState,
-  [PagesModelActions.tabbar.changeOptionalClass]: changeOptionalClass,
+  [PagesModelActions.tabbar.changeOptionalTabClass]: changeOptionalTabClass,
 }, new Model());

--- a/src/browser-frontend/reducers/pages-tabbar-reducers.js
+++ b/src/browser-frontend/reducers/pages-tabbar-reducers.js
@@ -19,6 +19,11 @@ function setTabState(state, { payload: { pageId, tabState } }) {
   return state.setIn(['ui', 'pages', 'visuals', pageId, 'tabState'], tabState);
 }
 
+function changeOptionalClass(state, { payload: { parentId, optionalClass } }) {
+  return state.setIn(['ui', 'pages', 'visuals', parentId, 'optionalClass'], optionalClass);
+}
+
 export default handleActions({
   [PagesModelActions.tabbar.setTabState]: setTabState,
+  [PagesModelActions.tabbar.changeOptionalClass]: changeOptionalClass,
 }, new Model());

--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -98,9 +98,11 @@ function* onPageDidNavigateInternal() {
 function* onPageDidNavigateToNewWindow({ payload: { parentId, url } }) {
   yield put(PagesModelActions.addPage({ parentId, url, background: false }));
 
-  yield put(PagesModelActions.tabbar.changeOptionalClass({ parentId, optionalClass: 'noanimate' }));
-  yield call(delay, 400);
-  yield put(PagesModelActions.tabbar.changeOptionalClass({ parentId, optionalClass: '' }));
+  // Add class to prevent the deselect animation of the parent tab when opening a child tab
+  // then remove class once deselect is finished.
+  yield put(PagesModelActions.tabbar.changeOptionalTabClass({ parentId, optionalClass: 'noanimate' }));
+  yield call(delay, 200);
+  yield put(PagesModelActions.tabbar.changeOptionalTabClass({ parentId, optionalClass: '' }));
 }
 
 export default function* () {

--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -10,6 +10,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
+import { delay } from 'redux-saga';
 import { takeEvery, call, put, select } from 'redux-saga/effects';
 
 import WebContents from '../../shared/widgets/web-contents';
@@ -96,6 +97,10 @@ function* onPageDidNavigateInternal() {
 
 function* onPageDidNavigateToNewWindow({ payload: { parentId, url } }) {
   yield put(PagesModelActions.addPage({ parentId, url, background: false }));
+
+  yield put(PagesModelActions.tabbar.changeOptionalClass({ parentId, optionalClass: 'noanimate' }));
+  yield call(delay, 400);
+  yield put(PagesModelActions.tabbar.changeOptionalClass({ parentId, optionalClass: '' }));
 }
 
 export default function* () {

--- a/src/browser-frontend/selectors/domain-pages-selectors.js
+++ b/src/browser-frontend/selectors/domain-pages-selectors.js
@@ -47,3 +47,7 @@ export function getPageFavicon(state, pageId) {
 export function getPageBookmarkedState(state, pageId) {
   return getPageMeta(state, pageId).get('bookmarked');
 }
+
+export function getPageOwnerId(state, pageId) {
+  return getPageMeta(state, pageId).get('tabOwner');
+}

--- a/src/browser-frontend/selectors/ui-pages-selectors.js
+++ b/src/browser-frontend/selectors/ui-pages-selectors.js
@@ -50,10 +50,6 @@ export function getOptionalClass(state, pageId) {
 
 // UI page computed properties getters.
 
-export function getPageDisplayOwner(state, pageId) {
-  return !!PagesSelectors.getPageOwnerId(state, pageId);
-}
-
 export function getComputedPageDisplayTitle(state, pageId) {
   const loadState = PagesSelectors.getPageLoadState(state, pageId);
   if (loadState === DomainPageMetaModel.LOAD_STATES.INITIAL ||

--- a/src/browser-frontend/selectors/ui-pages-selectors.js
+++ b/src/browser-frontend/selectors/ui-pages-selectors.js
@@ -44,6 +44,10 @@ export function getPageTabState(state, pageId) {
   return getPageVisuals(state, pageId).get('tabState');
 }
 
+export function getPageOwnerId(state, pageId) {
+  return getPageVisuals(state, pageId).get('tabOwner');
+}
+
 // UI page computed properties getters.
 
 export function getComputedPageDisplayTitle(state, pageId) {

--- a/src/browser-frontend/selectors/ui-pages-selectors.js
+++ b/src/browser-frontend/selectors/ui-pages-selectors.js
@@ -48,6 +48,10 @@ export function getPageOwnerId(state, pageId) {
   return getPageVisuals(state, pageId).get('tabOwner');
 }
 
+export function getOptionalClass(state, pageId) {
+  return getPageVisuals(state, pageId).get('optionalClass');
+}
+
 // UI page computed properties getters.
 
 export function getComputedPageDisplayTitle(state, pageId) {

--- a/src/browser-frontend/selectors/ui-pages-selectors.js
+++ b/src/browser-frontend/selectors/ui-pages-selectors.js
@@ -44,15 +44,15 @@ export function getPageTabState(state, pageId) {
   return getPageVisuals(state, pageId).get('tabState');
 }
 
-export function getPageOwnerId(state, pageId) {
-  return getPageVisuals(state, pageId).get('tabOwner');
-}
-
 export function getOptionalClass(state, pageId) {
   return getPageVisuals(state, pageId).get('optionalClass');
 }
 
 // UI page computed properties getters.
+
+export function getPageDisplayOwner(state, pageId) {
+  return !!PagesSelectors.getPageOwnerId(state, pageId);
+}
 
 export function getComputedPageDisplayTitle(state, pageId) {
   const loadState = PagesSelectors.getPageLoadState(state, pageId);

--- a/src/browser-frontend/views/browser/chrome/tabbar.css
+++ b/src/browser-frontend/views/browser/chrome/tabbar.css
@@ -16,7 +16,7 @@ specific language governing permissions and limitations under the License.
   box-sizing: border-box;
   flex: 1;
   padding: 0 10px;
-  padding-top: 10px;
+  padding-top: var(--theme-tabbar-top-padding);
   background: var(--theme-tabbar-background);
 }
 

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.css
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.css
@@ -45,7 +45,6 @@ specific language governing permissions and limitations under the License.
 .tab.initial {
   width: var(--theme-tab-initial-width);
   height: var(--theme-tab-initial-height);
-  opacity: var(--theme-tab-initial-opacity);
 }
 
 .tab.has-owner {

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.css
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.css
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 */
 
 .tab {
+  position: relative;
   overflow: hidden;
   width: var(--theme-tab-open-width);
   height: var(--theme-tab-open-height);
@@ -42,6 +43,32 @@ specific language governing permissions and limitations under the License.
   width: var(--theme-tab-initial-width);
   height: var(--theme-tab-initial-height);
   opacity: var(--theme-tab-initial-opacity);
+}
+
+.tab.has-owner {
+  left: 0;
+  transition:
+    width 0.05s var(--animation-curve),
+    background-position 0.2s var(--animation-curve),
+    height 0.2s var(--animation-curve),
+    left 0.2s var(--animation-curve);
+}
+
+.tab.has-owner * {
+  opacity: var(--theme-tab-open-opacity);
+  transform: translate(0, 0);
+  transition: opacity 0.2s 0.2s var(--animation-curve), transform 0.2s 0.2s var(--animation-curve);
+}
+
+.tab.has-owner.initial * {
+  opacity: var(--theme-tab-initial-opacity);
+  transform: translate(0, 30px);
+}
+
+.tab.has-owner.initial {
+  left: -190px;
+  width: var(--theme-tab-open-width);
+  height: var(--theme-tab-open-height);
 }
 
 .tab.closed {

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.css
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.css
@@ -84,3 +84,7 @@ specific language governing permissions and limitations under the License.
   color: var(--theme-tab-active-color);
   transition: width 0.05s  0.15s var(--animation-curve), height 0.2s var(--animation-curve);
 }
+
+.tab.noanimate {
+  transition: none !important;
+}

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.css
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.css
@@ -24,7 +24,10 @@ specific language governing permissions and limitations under the License.
   box-shadow: 1px 0 0 0 var(--theme-tab-separator-color);
   color: var(--theme-tab-inactive-color);
   composes: app-no-drag from '../../../../../shared/widgets/helpers/common.css';
-  transition: width 0.05s var(--animation-curve), background-position 0.2s var(--animation-curve), height 0.2s var(--animation-curve);
+  transition:
+    width 0.05s var(--animation-curve),
+    height 0.2s var(--animation-curve),
+    background-position 0.2s var(--animation-curve);
   user-select: none;
 }
 
@@ -48,25 +51,27 @@ specific language governing permissions and limitations under the License.
 .tab.has-owner {
   left: 0;
   transition:
+    left 0.2s var(--animation-curve),
     width 0.05s var(--animation-curve),
-    background-position 0.2s var(--animation-curve),
     height 0.2s var(--animation-curve),
-    left 0.2s var(--animation-curve);
+    background-position 0.2s var(--animation-curve);
 }
 
-.tab.has-owner * {
+.tab.has-owner > * {
   opacity: var(--theme-tab-open-opacity);
   transform: translate(0, 0);
-  transition: opacity 0.2s 0.2s var(--animation-curve), transform 0.2s 0.2s var(--animation-curve);
+  transition:
+    opacity 0.2s 0.2s var(--animation-curve),
+    transform 0.2s 0.2s var(--animation-curve);
 }
 
-.tab.has-owner.initial * {
+.tab.has-owner.initial > * {
   opacity: var(--theme-tab-initial-opacity);
-  transform: translate(0, 30px);
+  transform: translate(0, var(--theme-tab-open-height));
 }
 
 .tab.has-owner.initial {
-  left: -190px;
+  left: calc(0px - var(--theme-tab-open-width)); /* stylelint-disable-line */
   width: var(--theme-tab-open-width);
   height: var(--theme-tab-open-height);
 }
@@ -74,7 +79,9 @@ specific language governing permissions and limitations under the License.
 .tab.closed {
   width: var(--theme-tab-closed-width);
   opacity: var(--theme-tab-closed-opacity);
-  transition: width 0.2s var(--animation-curve), opacity 0.1s var(--animation-curve);
+  transition:
+    width 0.2s var(--animation-curve),
+    opacity 0.1s var(--animation-curve);
 }
 
 .tab.selected-closed {
@@ -82,7 +89,9 @@ specific language governing permissions and limitations under the License.
   height: var(--theme-tab-closed-height);
   background-position: var(--theme-tab-active-background-position);
   color: var(--theme-tab-active-color);
-  transition: width 0.05s  0.15s var(--animation-curve), height 0.2s var(--animation-curve);
+  transition:
+    width 0.05s 0.15s var(--animation-curve),
+    height 0.2s var(--animation-curve);
 }
 
 .tab.noanimate {

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
@@ -25,7 +25,7 @@ import TabContents from './tab/tab-contents';
   selected: UIPagesSelectors.getSelectedPageId(state) === ownProps.pageId,
   tooltipText: UIPagesSelectors.getComputedPageTooltipText(state, ownProps.pageId),
   tabState: UIPagesSelectors.getPageTabState(state, ownProps.pageId),
-  tabOwner: UIPagesSelectors.getPageOwnerId(state, ownProps.pageId),
+  tabOwner: UIPagesSelectors.getPageDisplayOwner(state, ownProps.pageId),
   optionalClass: UIPagesSelectors.getOptionalClass(state, ownProps.pageId),
 }))
 @CSSModules(Styles, {
@@ -68,6 +68,6 @@ Tab.WrappedComponent.propTypes = {
   selected: PropTypes.bool.isRequired,
   tooltipText: PropTypes.string.isRequired,
   tabState: PropTypes.string.isRequired,
-  tabOwner: PropTypes.string.isRequired,
+  tabOwner: PropTypes.bool.isRequired,
   optionalClass: PropTypes.string.isRequired,
 };

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
@@ -17,6 +17,7 @@ import { connect } from 'react-redux';
 import PagesModelActions from '../../../../actions/pages-model-actions';
 import UIPageModel from '../../../../model/ui-page-model';
 import * as UIPagesSelectors from '../../../../selectors/ui-pages-selectors';
+import * as DomainPagesSelectors from '../../../../selectors/domain-pages-selectors';
 
 import Styles from './tab.css';
 import TabContents from './tab/tab-contents';
@@ -25,7 +26,7 @@ import TabContents from './tab/tab-contents';
   selected: UIPagesSelectors.getSelectedPageId(state) === ownProps.pageId,
   tooltipText: UIPagesSelectors.getComputedPageTooltipText(state, ownProps.pageId),
   tabState: UIPagesSelectors.getPageTabState(state, ownProps.pageId),
-  tabOwner: UIPagesSelectors.getPageDisplayOwner(state, ownProps.pageId),
+  tabOwner: !!DomainPagesSelectors.getPageOwnerId(state, ownProps.pageId),
   optionalClass: UIPagesSelectors.getOptionalClass(state, ownProps.pageId),
 }))
 @CSSModules(Styles, {

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
@@ -26,6 +26,7 @@ import TabContents from './tab/tab-contents';
   tooltipText: UIPagesSelectors.getComputedPageTooltipText(state, ownProps.pageId),
   tabState: UIPagesSelectors.getPageTabState(state, ownProps.pageId),
   tabOwner: UIPagesSelectors.getPageOwnerId(state, ownProps.pageId),
+  optionalClass: UIPagesSelectors.getOptionalClass(state, ownProps.pageId),
 }))
 @CSSModules(Styles, {
   allowMultiple: true,
@@ -49,7 +50,8 @@ export default class Tab extends PureComponent {
         styleName={`tab \
           ${this.props.selected ? 'selected' : ''} \
           ${this.props.tabState !== 'open' ? this.props.tabState : ''} \
-          ${this.props.tabOwner ? 'has-owner' : ''}`
+          ${this.props.tabOwner ? 'has-owner' : ''} \
+          ${this.props.optionalClass}`
         }
         title={this.props.tooltipText}
         onClick={this.handleClick}
@@ -67,4 +69,5 @@ Tab.WrappedComponent.propTypes = {
   tooltipText: PropTypes.string.isRequired,
   tabState: PropTypes.string.isRequired,
   tabOwner: PropTypes.string.isRequired,
+  optionalClass: PropTypes.string.isRequired,
 };

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
@@ -25,6 +25,7 @@ import TabContents from './tab/tab-contents';
   selected: UIPagesSelectors.getSelectedPageId(state) === ownProps.pageId,
   tooltipText: UIPagesSelectors.getComputedPageTooltipText(state, ownProps.pageId),
   tabState: UIPagesSelectors.getPageTabState(state, ownProps.pageId),
+  tabOwner: UIPagesSelectors.getPageOwnerId(state, ownProps.pageId),
 }))
 @CSSModules(Styles, {
   allowMultiple: true,
@@ -47,7 +48,9 @@ export default class Tab extends PureComponent {
         tabIndex={0}
         styleName={`tab \
           ${this.props.selected ? 'selected' : ''} \
-          ${this.props.tabState !== 'open' ? this.props.tabState : ''}`}
+          ${this.props.tabState !== 'open' ? this.props.tabState : ''} \
+          ${this.props.tabOwner ? 'has-owner' : ''}`
+        }
         title={this.props.tooltipText}
         onClick={this.handleClick}
       >
@@ -63,4 +66,5 @@ Tab.WrappedComponent.propTypes = {
   selected: PropTypes.bool.isRequired,
   tooltipText: PropTypes.string.isRequired,
   tabState: PropTypes.string.isRequired,
+  tabOwner: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
~~todo: add a no-animation class to the parent tab to stop the slide-down effect as it becomes unselected (a little lost on how to do this.... if anyone has advice, @bwinton @victorporof?)~~

`noanimation` class is added to parent tab, and removed 400ms later, this is not perfect, but works for the prototype

Fixes: https://github.com/victorporof/tofino/issues/27.