### PR TITLE
fix: Parent tab slide-down animnation

### DIFF
--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -113,7 +113,7 @@ function* onPageDidNavigateToNewWindow({ payload: { parentId, url } }) {
 
   // Add class to prevent the deselect animation of the parent tab when opening a child tab
   // then remove class once deselect is finished.
-  yield put(PagesModelActions.tabbar.changeOptionalTabClass({ parentId, optionalClass: 'noanimate' }));
+  yield put(PagesModelActions.tabbar.changeOptionalTabClass({ pageId: parentId, optionalClass: 'noanimate' }));
   yield call(delay, 200);
   yield put(PagesModelActions.tabbar.changeOptionalTabClass({ parentId, optionalClass: '' }));
 }


### PR DESCRIPTION
oops, cannot force dictionary names to change.

I noticed the slide-down animation was still happening, turns out changing a variable name was stopping the class from ever being applied. 