### PR TITLE
Fix tab loading animations

### DIFF
--- a/build/tasks/task-browser-frontend.js
+++ b/build/tasks/task-browser-frontend.js
@@ -28,6 +28,12 @@ gulp.task('browser-frontend:copy-html', () =>
     .pipe(debug({ title: `Running ${colors.cyan('cp')}` }))
     .pipe(gulp.dest(Paths.BROWSER_FRONTEND_DST)));
 
+gulp.task('browser-frontend:copy-gifs', () =>
+  gulp.src(`${Paths.BROWSER_FRONTEND_SRC}/**/*.gif`)
+    .pipe(changed(Paths.BROWSER_FRONTEND_DST))
+    .pipe(debug({ title: `Running ${colors.cyan('cp')}` }))
+    .pipe(gulp.dest(Paths.BROWSER_FRONTEND_DST)));
+
 gulp.task('browser-frontend:copy-to-qbrt-shell', () =>
   gulp.src(`${Paths.BROWSER_FRONTEND_DST}/**/*`)
     .pipe(changed(Paths.QBRT_RUNNER_SHELL_DST))
@@ -62,6 +68,7 @@ gulp.task('browser-frontend:webpack', () => new Promise((resolve, reject) => {
 
 gulp.task('browser-frontend:build', gulp.series(
   'browser-frontend:copy-html',
+  'browser-frontend:copy-gifs',
   'browser-frontend:webpack',
   'browser-frontend:copy-to-qbrt-shell',
 ));

--- a/src/browser-frontend/actions/pages-model-actions.js
+++ b/src/browser-frontend/actions/pages-model-actions.js
@@ -26,8 +26,11 @@ export default createActions({
   SELECT_NEXT_LOGICAL_PAGE: identity,
   TABBAR: {
     SET_TAB_STATE: identity,
+    PREVENT_ALL_TAB_ANIMATIONS: identity,
+    ALLOW_ALL_TAB_ANIMATIONS: identity,
+    START_TAB_LOADED_ANIMATION: identity,
+    STOP_TAB_LOADED_ANIMATION: identity,
     CLOSE_TAB_ANIMATED: identity,
-    CHANGE_OPTIONAL_TAB_CLASS: identity,
   },
   NAVBAR: {
     SET_LOCATION_INPUT_BAR_VALUE: identity,

--- a/src/browser-frontend/css/theme.css
+++ b/src/browser-frontend/css/theme.css
@@ -81,8 +81,6 @@
   --theme-close-tab-button-image: url('../assets/Stop - 16.svg');
   --theme-tab-background-size: 100% 200%;
   --theme-tab-background-repeat: no-repeat;
-  --theme-active-tab-background-loaded: url('../assets/wipe-blue.gif');
-  --theme-inactive-tab-background-loaded: url('../assets/wipe-grey.gif');
 
   /* Navbar */
 

--- a/src/browser-frontend/model/ui-page-model.js
+++ b/src/browser-frontend/model/ui-page-model.js
@@ -15,8 +15,8 @@ import Immutable from 'immutable';
 const TAB_STATES = {
   INITIAL: 'initial',
   OPEN: 'open',
-  CLOSED: 'closed',
-  SELECTEDCLOSED: 'selected-closed',
+  BACKGROUND_CLOSED: 'background-closed',
+  FOREGROUND_CLOSED: 'foreground-closed',
 };
 
 const UIPageModel = Immutable.Record({

--- a/src/browser-frontend/model/ui-page-model.js
+++ b/src/browser-frontend/model/ui-page-model.js
@@ -14,7 +14,6 @@ import Immutable from 'immutable';
 
 const TAB_STATES = {
   INITIAL: 'initial',
-  TABLOADED: 'tab-loaded',
   OPEN: 'open',
   CLOSED: 'closed',
   SELECTEDCLOSED: 'selected-closed',
@@ -22,8 +21,9 @@ const TAB_STATES = {
 
 const UIPageModel = Immutable.Record({
   tabState: TAB_STATES.INITIAL,
+  tabAnimationsDisabled: false,
+  tabLoadAnimationRunning: false,
   locationInputBarValue: '',
-  optionalClass: '',
 });
 
 UIPageModel.TAB_STATES = TAB_STATES;

--- a/src/browser-frontend/reducers/pages-tabbar-reducers.js
+++ b/src/browser-frontend/reducers/pages-tabbar-reducers.js
@@ -32,7 +32,11 @@ function startTabLoadedAnimation(state, { payload: { pageId } }) {
 }
 
 function stopTabLoadedAnimation(state, { payload: { pageId } }) {
-  return state.setIn(['ui', 'pages', 'visuals', pageId, 'tabLoadAnimationRunning'], false);
+  return state.withMutations((mut) => {
+    const playCount = state.ui.pages.visuals.get(pageId).tabLoadAnimationPlayCount;
+    mut.setIn(['ui', 'pages', 'visuals', pageId, 'tabLoadAnimationRunning'], false);
+    mut.setIn(['ui', 'pages', 'visuals', pageId, 'tabLoadAnimationPlayCount'], playCount + 1);
+  });
 }
 
 export default handleActions({

--- a/src/browser-frontend/reducers/pages-tabbar-reducers.js
+++ b/src/browser-frontend/reducers/pages-tabbar-reducers.js
@@ -19,11 +19,26 @@ function setTabState(state, { payload: { pageId, tabState } }) {
   return state.setIn(['ui', 'pages', 'visuals', pageId, 'tabState'], tabState);
 }
 
-function changeOptionalTabClass(state, { payload: { pageId, optionalClass } }) {
-  return state.setIn(['ui', 'pages', 'visuals', pageId, 'optionalClass'], optionalClass);
+function preventAllTabAnimations(state, { payload: { pageId } }) {
+  return state.setIn(['ui', 'pages', 'visuals', pageId, 'tabAnimationsDisabled'], true);
+}
+
+function allowAllTabAnimations(state, { payload: { pageId } }) {
+  return state.setIn(['ui', 'pages', 'visuals', pageId, 'tabAnimationsDisabled'], false);
+}
+
+function startTabLoadedAnimation(state, { payload: { pageId } }) {
+  return state.setIn(['ui', 'pages', 'visuals', pageId, 'tabLoadAnimationRunning'], true);
+}
+
+function stopTabLoadedAnimation(state, { payload: { pageId } }) {
+  return state.setIn(['ui', 'pages', 'visuals', pageId, 'tabLoadAnimationRunning'], false);
 }
 
 export default handleActions({
   [PagesModelActions.tabbar.setTabState]: setTabState,
-  [PagesModelActions.tabbar.changeOptionalTabClass]: changeOptionalTabClass,
+  [PagesModelActions.tabbar.preventAllTabAnimations]: preventAllTabAnimations,
+  [PagesModelActions.tabbar.allowAllTabAnimations]: allowAllTabAnimations,
+  [PagesModelActions.tabbar.startTabLoadedAnimation]: startTabLoadedAnimation,
+  [PagesModelActions.tabbar.stopTabLoadedAnimation]: stopTabLoadedAnimation,
 }, new Model());

--- a/src/browser-frontend/sagas/tabs-action-handlers.js
+++ b/src/browser-frontend/sagas/tabs-action-handlers.js
@@ -20,8 +20,8 @@ import { getSelectedPageId } from '../selectors/ui-pages-selectors';
 function* closeTabAnimated({ payload: { pageId, removePageAfterMs } }) {
   const selectedPageId = yield select(getSelectedPageId);
   const tabState = selectedPageId === pageId
-  ? UIPageModel.TAB_STATES.SELECTEDCLOSED
-  : UIPageModel.TAB_STATES.CLOSED;
+    ? UIPageModel.TAB_STATES.FOREGROUND_CLOSED
+    : UIPageModel.TAB_STATES.BACKGROUND_CLOSED;
 
   yield put(PagesModelActions.tabbar.setTabState({
     pageId,

--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -58,17 +58,10 @@ function* onPageDidStopLoading({ payload: { pageId } }) {
     loadState: DomainPageMetaModel.LOAD_STATES.LOADED,
   }));
 
-  // Set the tab state class in order to show the loaded flash,
-  // then once we are sure the flash is finished set the tab back to the usual state.
-  yield put(PagesModelActions.tabbar.setTabState({
-    pageId,
-    tabState: UIPageModel.TAB_STATES.TABLOADED,
-  }));
+  // Show the tab loaded flash.
+  yield put(PagesModelActions.tabbar.startTabLoadedAnimation({ pageId }));
   yield call(delay, 400);
-  yield put(PagesModelActions.tabbar.setTabState({
-    pageId,
-    tabState: UIPageModel.TAB_STATES.OPEN,
-  }));
+  yield put(PagesModelActions.tabbar.stopTabLoadedAnimation({ pageId }));
 }
 
 function* onPageDidSucceedLoad() {
@@ -111,11 +104,10 @@ function* onPageDidNavigateInternal() {
 function* onPageDidNavigateToNewWindow({ payload: { parentId, url } }) {
   yield put(PagesModelActions.addPage({ parentId, url, background: false }));
 
-  // Add class to prevent the deselect animation of the parent tab when opening a child tab
-  // then remove class once deselect is finished.
-  yield put(PagesModelActions.tabbar.changeOptionalTabClass({ pageId: parentId, optionalClass: 'noanimate' }));
+  // Prevent the deselect animation of the parent tab when opening a child tab.
+  yield put(PagesModelActions.tabbar.preventAllTabAnimations({ pageId: parentId }));
   yield call(delay, 200);
-  yield put(PagesModelActions.tabbar.changeOptionalTabClass({ parentId, optionalClass: '' }));
+  yield put(PagesModelActions.tabbar.allowAllTabAnimations({ pageId: parentId }));
 }
 
 export default function* () {

--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -16,7 +16,6 @@ import { takeEvery, call, put, select } from 'redux-saga/effects';
 import WebContents from '../../shared/widgets/web-contents';
 import WebContentsActions from '../actions/webcontents-actions';
 import PagesModelActions from '../actions/pages-model-actions';
-import UIPageModel from '../model/ui-page-model';
 import DomainPageMetaModel from '../model/domain-page-meta-model';
 import * as DomainPagesSelectors from '../selectors/domain-pages-selectors';
 

--- a/src/browser-frontend/selectors/ui-pages-selectors.js
+++ b/src/browser-frontend/selectors/ui-pages-selectors.js
@@ -52,6 +52,10 @@ export function getTabLoadAnimationRunning(state, pageId) {
   return getPageVisuals(state, pageId).get('tabLoadAnimationRunning');
 }
 
+export function getTabLoadAnimationPlayCount(state, pageId) {
+  return getPageVisuals(state, pageId).get('tabLoadAnimationPlayCount');
+}
+
 // UI page computed properties getters.
 
 export function getComputedPageDisplayTitle(state, pageId) {

--- a/src/browser-frontend/selectors/ui-pages-selectors.js
+++ b/src/browser-frontend/selectors/ui-pages-selectors.js
@@ -44,8 +44,12 @@ export function getPageTabState(state, pageId) {
   return getPageVisuals(state, pageId).get('tabState');
 }
 
-export function getOptionalClass(state, pageId) {
-  return getPageVisuals(state, pageId).get('optionalClass');
+export function getTabAnimationsDisabled(state, pageId) {
+  return getPageVisuals(state, pageId).get('tabAnimationsDisabled');
+}
+
+export function getTabLoadAnimationRunning(state, pageId) {
+  return getPageVisuals(state, pageId).get('tabLoadAnimationRunning');
 }
 
 // UI page computed properties getters.

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.css
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.css
@@ -31,7 +31,7 @@ specific language governing permissions and limitations under the License.
   user-select: none;
 }
 
-.tab:not(.selected):not(.selected-closed):hover {
+.tab:not(.selected):not(.foreground-closed):hover {
   background: var(--theme-tab-hover-background);
   color: var(--theme-tab-hover-color);
 }
@@ -75,7 +75,7 @@ specific language governing permissions and limitations under the License.
   height: var(--theme-tab-open-height);
 }
 
-.tab.closed {
+.tab.background-closed {
   width: var(--theme-tab-closed-width);
   opacity: var(--theme-tab-closed-opacity);
   transition:
@@ -83,7 +83,7 @@ specific language governing permissions and limitations under the License.
     opacity 0.1s var(--animation-curve);
 }
 
-.tab.selected-closed {
+.tab.foreground-closed {
   width: var(--theme-tab-closed-width);
   height: var(--theme-tab-closed-height);
   background-position: var(--theme-tab-active-background-position);

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.css
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.css
@@ -98,11 +98,9 @@ specific language governing permissions and limitations under the License.
 }
 
 .tab.tab-loaded {
-  background-image: var(--theme-inactive-tab-background-loaded);
   background-position: var(--theme-tab-inactive-background-position);
 }
 
 .tab.selected.tab-loaded {
-  background-image: var(--theme-active-tab-background-loaded);
   background-position: var(--theme-tab-active-background-position);
 }

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
@@ -27,7 +27,8 @@ import TabContents from './tab/tab-contents';
   tooltipText: UIPagesSelectors.getComputedPageTooltipText(state, ownProps.pageId),
   tabState: UIPagesSelectors.getPageTabState(state, ownProps.pageId),
   tabOwner: !!DomainPagesSelectors.getPageOwnerId(state, ownProps.pageId),
-  optionalClass: UIPagesSelectors.getOptionalClass(state, ownProps.pageId),
+  tabAnimationsDisabled: UIPagesSelectors.getTabAnimationsDisabled(state, ownProps.pageId),
+  tabLoadAnimationRunning: UIPagesSelectors.getTabLoadAnimationRunning(state, ownProps.pageId),
 }))
 @CSSModules(Styles, {
   allowMultiple: true,
@@ -52,7 +53,8 @@ export default class Tab extends PureComponent {
           ${this.props.selected ? 'selected' : ''} \
           ${this.props.tabState !== 'open' ? this.props.tabState : ''} \
           ${this.props.tabOwner ? 'has-owner' : ''} \
-          ${this.props.optionalClass}`
+          ${this.props.tabAnimationsDisabled ? 'noanimate' : ''} \
+          ${this.props.tabLoadAnimationRunning ? 'tab-loaded' : ''}`
         }
         title={this.props.tooltipText}
         onClick={this.handleClick}
@@ -70,5 +72,6 @@ Tab.WrappedComponent.propTypes = {
   tooltipText: PropTypes.string.isRequired,
   tabState: PropTypes.string.isRequired,
   tabOwner: PropTypes.bool.isRequired,
-  optionalClass: PropTypes.string.isRequired,
+  tabAnimationsDisabled: PropTypes.bool.isRequired,
+  tabLoadAnimationRunning: PropTypes.bool.isRequired,
 };

--- a/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
+++ b/src/browser-frontend/views/browser/chrome/tabbar/tab.jsx
@@ -21,6 +21,7 @@ import * as DomainPagesSelectors from '../../../../selectors/domain-pages-select
 
 import Styles from './tab.css';
 import TabContents from './tab/tab-contents';
+import PreloadImage from '../../../../../shared/widgets/preload-image';
 
 @connect((state, ownProps) => ({
   selected: UIPagesSelectors.getSelectedPageId(state) === ownProps.pageId,
@@ -29,6 +30,7 @@ import TabContents from './tab/tab-contents';
   tabOwner: !!DomainPagesSelectors.getPageOwnerId(state, ownProps.pageId),
   tabAnimationsDisabled: UIPagesSelectors.getTabAnimationsDisabled(state, ownProps.pageId),
   tabLoadAnimationRunning: UIPagesSelectors.getTabLoadAnimationRunning(state, ownProps.pageId),
+  tabLoadAnimationPlayCount: UIPagesSelectors.getTabLoadAnimationPlayCount(state, ownProps.pageId),
 }))
 @CSSModules(Styles, {
   allowMultiple: true,
@@ -46,6 +48,10 @@ export default class Tab extends PureComponent {
   }
 
   render() {
+    const activeTabLoadAnimation =
+      `url('assets/wipe-blue.gif?${this.props.pageId}-${this.props.tabLoadAnimationPlayCount}')`;
+    const inactiveTabLoadAnimation =
+      `url('assets/wipe-grey.gif?${this.props.pageId}-${this.props.tabLoadAnimationPlayCount}')`;
     return (
       <a
         tabIndex={0}
@@ -58,7 +64,18 @@ export default class Tab extends PureComponent {
         }
         title={this.props.tooltipText}
         onClick={this.handleClick}
+        style={{
+          ...(this.props.tabLoadAnimationRunning ? {
+            ...(this.props.selected ? {
+              backgroundImage: activeTabLoadAnimation,
+            } : {
+              backgroundImage: inactiveTabLoadAnimation,
+            }),
+          } : {}),
+        }}
       >
+        <PreloadImage src={activeTabLoadAnimation} />
+        <PreloadImage src={inactiveTabLoadAnimation} />
         <TabContents pageId={this.props.pageId} />
       </a>
     );
@@ -74,4 +91,5 @@ Tab.WrappedComponent.propTypes = {
   tabOwner: PropTypes.bool.isRequired,
   tabAnimationsDisabled: PropTypes.bool.isRequired,
   tabLoadAnimationRunning: PropTypes.bool.isRequired,
+  tabLoadAnimationPlayCount: PropTypes.number.isRequired,
 };

--- a/src/shared/widgets/preload-image.jsx
+++ b/src/shared/widgets/preload-image.jsx
@@ -10,23 +10,23 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-import Immutable from 'immutable';
+import React, { PropTypes } from 'react';
 
-const TAB_STATES = {
-  INITIAL: 'initial',
-  OPEN: 'open',
-  BACKGROUND_CLOSED: 'background-closed',
-  FOREGROUND_CLOSED: 'foreground-closed',
+import WidgetComponent from './helpers/widget-component';
+
+export default class PreloadImage extends WidgetComponent {
+  render() {
+    return (
+      <span
+        style={{
+          backgroundImage: this.props.src,
+        }}
+      />
+    );
+  }
+}
+
+PreloadImage.propTypes = {
+  src: PropTypes.string.isRequired,
 };
 
-const UIPageModel = Immutable.Record({
-  tabState: TAB_STATES.INITIAL,
-  tabAnimationsDisabled: false,
-  tabLoadAnimationRunning: false,
-  tabLoadAnimationPlayCount: 0,
-  locationInputBarValue: '',
-});
-
-UIPageModel.TAB_STATES = TAB_STATES;
-
-export default UIPageModel;


### PR DESCRIPTION
Closes https://github.com/victorporof/tofino/issues/67

This PR does a few things:

1. It thins down the TAB_STATES enum. Upon further investigation, it's incorrect to conflate all of those values into "either-or" options, since multiple choices can conceptually be true at the same time. We've actually introduced a bug where tab states wouldn't correctly revert to their correct state when closed while the "loaded flash" animation was running. This commit simply splits those out into multiple state properties.

2. It 	renames the CLOSED and SELECTEDCLOSED tab states to something marginally more suggestive. This is opinionated and isn't crucial.

3. Prevents gif caching, allowing tabs to display the "loaded flash" for every load event. Commit (1) is necessary for this to work as well.