### PR TITLE
Fix keyboard shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "fs-promise": "2.0.2",
     "immutable": "3.8.1",
     "is-browser": "2.0.1",
+    "is-uuid": "1.0.2",
     "less": "2.7.2",
     "lodash": "4.17.4",
     "morgan": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "colour": "github:victorporof/colour.js#safe",
     "dateformat": "2.0.0",
     "electron": "1.6.2",
+    "electron-localshortcut": "1.1.1",
     "express": "4.15.2",
     "express-http-proxy": "0.11.0",
     "font-awesome": "4.7.0",

--- a/src/browser-frontend/actions/keyboard-shortcuts-actions.js
+++ b/src/browser-frontend/actions/keyboard-shortcuts-actions.js
@@ -10,16 +10,12 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-import serverEventHandlers from './server-event-handlers';
-import keyboardShortcutsActionHandlers from './keyboard-shortcuts-action-handlers';
-import webContentsActionHandlers from './webcontents-action-handlers';
-import tabsActionHandlers from './tabs-action-handlers';
+import { createActions } from 'redux-actions';
+import identity from 'lodash/identity';
 
-export default function* () {
-  yield [
-    serverEventHandlers(),
-    keyboardShortcutsActionHandlers(),
-    webContentsActionHandlers(),
-    tabsActionHandlers(),
-  ];
-}
+export default createActions({
+  PRESSED_ACCEL_Q: identity,
+  PRESSED_ACCEL_W: identity,
+  PRESSED_ACCEL_T: identity,
+  PRESSED_CAT_GIFS_EASTER_EGG: identity,
+});

--- a/src/browser-frontend/index.js
+++ b/src/browser-frontend/index.js
@@ -18,9 +18,13 @@ import './css/theme.css';
 import * as Global from './global';
 import { setupWs, setupFrontend, setupInitialState } from './setup';
 
-setupWs(Global.client);
-setupFrontend(Global.store, document, '.container');
-setupInitialState(Global.store);
+const main = async () => {
+  await setupWs(Global.client);
+  setupFrontend(Global.store, document, '.container');
+  setupInitialState(Global.store);
+};
+
+main();
 
 if (module.hot) {
   module.hot.accept('./views/browser/window', () => setupFrontend());

--- a/src/browser-frontend/model/domain-page-model.js
+++ b/src/browser-frontend/model/domain-page-model.js
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 */
 
 import Immutable from 'immutable';
+import isUUID from 'is-uuid';
 
 import DomainPageMetaModel from './domain-page-meta-model';
 
@@ -22,6 +23,9 @@ export default class DomainPageModel extends Immutable.Record({
   constructor(properties) {
     if (!properties || !properties.id || !properties.url) {
       throw new Error('Required properties missing from page constructor.');
+    }
+    if (!isUUID.v4(properties.id)) {
+      throw new Error('Malformed page id');
     }
     super(properties);
   }

--- a/src/browser-frontend/reducers/pages-reducers.js
+++ b/src/browser-frontend/reducers/pages-reducers.js
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 
 import { handleActions } from 'redux-actions';
 import uuid from 'uuid/v4';
+import isUUID from 'is-uuid';
 
 import Model from '../model';
 import * as Endpoints from '../constants/endpoints';
@@ -44,6 +45,10 @@ function addPage(state, { payload: { url, parentId, background } = {} }) {
 }
 
 function removePage(state, { payload: { pageId, withoutSelectingNextLogicalPage } }) {
+  if (!isUUID.v4(pageId)) {
+    throw new Error('Can\'t remove page with malformed id.');
+  }
+
   return state.withMutations((mut) => {
     const pageIndex = state.ui.pages.displayOrder.findIndex(id => id === pageId);
     const pageCount = state.ui.pages.displayOrder.count();

--- a/src/browser-frontend/sagas/keyboard-shortcuts-action-handlers.js
+++ b/src/browser-frontend/sagas/keyboard-shortcuts-action-handlers.js
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import { takeEvery, call, put, select } from 'redux-saga/effects';
+
+import { client } from '../global';
+import SharedActions from '../../shared/actions/shared-actions';
+import KeyboardShortcutsActions from '../actions/keyboard-shortcuts-actions';
+import PagesModelActions from '../actions/pages-model-actions';
+import * as DomainPagesSelectors from '../selectors/domain-pages-selectors';
+import * as UIPagesSelectors from '../selectors/ui-pages-selectors';
+
+function* handleAccelQ() {
+  yield call([client, client.send], SharedActions.events.fromFrontend.toServer.app.window.requestedQuit());
+}
+
+function* handleAccelW() {
+  const count = (yield select(DomainPagesSelectors.getPages)).count();
+  if (count === 1) {
+    client.send(SharedActions.events.fromFrontend.toServer.app.window.requestedClose());
+    return;
+  }
+
+  const selectedPageId = yield select(UIPagesSelectors.getSelectedPageId);
+  yield put(PagesModelActions.removePage({ pageId: selectedPageId }));
+}
+
+function* handleAccelT() {
+  yield put(PagesModelActions.addPage());
+}
+
+function* handleCatGifsEasterEgg() {
+  const url = 'http://chilloutandwatchsomecatgifs.com/';
+  yield put(PagesModelActions.addPage({ url }));
+}
+
+export default function* () {
+  yield [
+    takeEvery(KeyboardShortcutsActions.pressedAccelQ, handleAccelQ),
+    takeEvery(KeyboardShortcutsActions.pressedAccelW, handleAccelW),
+    takeEvery(KeyboardShortcutsActions.pressedAccelT, handleAccelT),
+    takeEvery(KeyboardShortcutsActions.pressedCatGifsEasterEgg, handleCatGifsEasterEgg),
+  ];
+}

--- a/src/browser-frontend/sagas/root-saga.js
+++ b/src/browser-frontend/sagas/root-saga.js
@@ -10,11 +10,13 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
+import serverEventHandlers from './server-event-handlers';
 import webContentsActionHandlers from './webcontents-action-handlers';
 import tabsActionHandlers from './tabs-action-handlers';
 
 export default function* () {
   yield [
+    serverEventHandlers(),
     webContentsActionHandlers(),
     tabsActionHandlers(),
   ];

--- a/src/browser-frontend/sagas/server-event-handlers.js
+++ b/src/browser-frontend/sagas/server-event-handlers.js
@@ -10,33 +10,20 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-import { takeEvery, call, put, select } from 'redux-saga/effects';
+import { takeEvery, put } from 'redux-saga/effects';
 
 import SharedActions from '../../shared/actions/shared-actions';
-import PagesModelActions from '../actions/pages-model-actions';
-import * as DomainPagesSelectors from '../selectors/domain-pages-selectors';
-import * as UIPagesSelectors from '../selectors/ui-pages-selectors';
+import KeyboardShortcutsActions from '../actions/keyboard-shortcuts-actions';
 
-function* handleAccelQ({ meta: client }) {
-  yield call([client, client.send], SharedActions.events.fromFrontend.toServer.app.window.requestedQuit());
-}
-
-function* handleAccelW({ meta: client }) {
-  const count = (yield select(DomainPagesSelectors.getPages)).count();
-  if (count === 1) {
-    client.send(SharedActions.events.fromFrontend.toServer.app.window.requestedClose());
-    return;
-  }
-
-  const selectedPageId = yield select(UIPagesSelectors.getSelectedPageId);
-  yield put(PagesModelActions.removePage({ pageId: selectedPageId }));
-}
-
-function* onKeyShortcutPressed({ meta: client, payload: { shortcut } }) {
+// Some keyboard shortcuts need to be registered at the platform level,
+// because they clash with OS-level shortcuts (e.g. Cmd+W on macOS
+// hides windows, but we want it to close tabs instead.). The platform
+// is tasked with overriding these shortcuts and providing us control.
+function* onKeyShortcutPressed({ payload: { shortcut } }) {
   if (shortcut.keys === 'CommandOrControl+Q') {
-    yield* handleAccelQ({ meta: client });
+    yield put(KeyboardShortcutsActions.pressedAccelQ());
   } else if (shortcut.keys === 'CommandOrControl+W') {
-    yield* handleAccelW({ meta: client });
+    yield put(KeyboardShortcutsActions.pressedAccelW());
   }
 }
 

--- a/src/browser-frontend/sagas/server-event-handlers.js
+++ b/src/browser-frontend/sagas/server-event-handlers.js
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import { takeEvery, call, put, select } from 'redux-saga/effects';
+
+import SharedActions from '../../shared/actions/shared-actions';
+import PagesModelActions from '../actions/pages-model-actions';
+import * as DomainPagesSelectors from '../selectors/domain-pages-selectors';
+import * as UIPagesSelectors from '../selectors/ui-pages-selectors';
+
+function* handleAccelQ({ meta: client }) {
+  yield call([client, client.send], SharedActions.events.fromFrontend.toServer.app.window.requestedQuit());
+}
+
+function* handleAccelW({ meta: client }) {
+  const count = (yield select(DomainPagesSelectors.getPages)).count();
+  if (count === 1) {
+    client.send(SharedActions.events.fromFrontend.toServer.app.window.requestedClose());
+    return;
+  }
+
+  const selectedPageId = yield select(UIPagesSelectors.getSelectedPageId);
+  yield put(PagesModelActions.removePage({ pageId: selectedPageId }));
+}
+
+function* onKeyShortcutPressed({ meta: client, payload: { shortcut } }) {
+  if (shortcut.keys === 'CommandOrControl+Q') {
+    yield* handleAccelQ({ meta: client });
+  } else if (shortcut.keys === 'CommandOrControl+W') {
+    yield* handleAccelW({ meta: client });
+  }
+}
+
+export default function* () {
+  yield [
+    takeEvery(SharedActions.events.fromServer.toFrontend.app.window.keyShortcuts.pressed, onKeyShortcutPressed),
+  ];
+}

--- a/src/browser-frontend/sagas/webcontents-action-handlers.js
+++ b/src/browser-frontend/sagas/webcontents-action-handlers.js
@@ -60,7 +60,11 @@ function* onPageDidStopLoading({ payload: { pageId } }) {
   // Show the tab loaded flash.
   yield put(PagesModelActions.tabbar.startTabLoadedAnimation({ pageId }));
   yield call(delay, 400);
-  yield put(PagesModelActions.tabbar.stopTabLoadedAnimation({ pageId }));
+
+  // If the page still exists at this point, hide the tab loaded flash.
+  if (yield select(DomainPagesSelectors.getPageById, pageId)) {
+    yield put(PagesModelActions.tabbar.stopTabLoadedAnimation({ pageId }));
+  }
 }
 
 function* onPageDidSucceedLoad() {
@@ -106,7 +110,11 @@ function* onPageDidNavigateToNewWindow({ payload: { parentId, url } }) {
   // Prevent the deselect animation of the parent tab when opening a child tab.
   yield put(PagesModelActions.tabbar.preventAllTabAnimations({ pageId: parentId }));
   yield call(delay, 200);
-  yield put(PagesModelActions.tabbar.allowAllTabAnimations({ pageId: parentId }));
+
+  // If the page still exists at this point, allow animations again.
+  if (yield select(DomainPagesSelectors.getPageById, parentId)) {
+    yield put(PagesModelActions.tabbar.allowAllTabAnimations({ pageId: parentId }));
+  }
 }
 
 export default function* () {

--- a/src/browser-frontend/views/browser/window.jsx
+++ b/src/browser-frontend/views/browser/window.jsx
@@ -17,9 +17,8 @@ import Mousetrap from 'mousetrap';
 
 import { client } from '../../global';
 import PagesModelActions from '../../actions/pages-model-actions';
-// import * as SharedPropTypes from '../../model/shared-prop-types';
-// import SharedActions from '../../../shared/actions/shared-actions';
-// import * as UIPagesSelectors from '../../selectors/ui-pages-selectors';
+import * as SharedPropTypes from '../../model/shared-prop-types';
+import SharedActions from '../../../shared/actions/shared-actions';
 
 import Styles from './window.css';
 import Chrome from './chrome';
@@ -33,19 +32,20 @@ import Content from './content';
 })
 export default class Window extends PureComponent {
   componentDidMount() {
+    // Some keyboard shortcuts need to be registered at the platform level,
+    // because they clash with OS-level shortcuts (e.g. Cmd+W on macOS
+    // hides windows, but we want it to close tabs instead.). The platform
+    // is tasked with overriding these shortcuts and providing us control.
+    this.props.client.send(SharedActions.commands.fromFrontend.toServer.app.window.keyShortcuts.register([
+      { keys: 'CommandOrControl+Q' },
+      { keys: 'CommandOrControl+W' },
+    ]));
+
+    // For everything else, listening to key events in the frontend is fine.
     this.mousetrap = Mousetrap();
     this.mousetrap.bind('mod+t', () => {
       this.props.dispatch(PagesModelActions.addPage());
     });
-    // this.mousetrap.bind('mod+q', () => {
-    //   this.props.client.send(SharedActions.events.fromFrontend.toServer.app.window.requestedClose());
-    // });
-    // this.mousetrap.bind('mod+w', () => {
-    //   this.props.dispatch((dispatch, getState) => {
-    //     const pageId = UIPagesSelectors.getSelectedPageId(getState());
-    //     this.props.dispatch(PagesModelActions.removePage({ pageId }));
-    //   });
-    // });
     this.mousetrap.bind('up up down down left right left right b a', () => {
       const url = 'http://chilloutandwatchsomecatgifs.com/';
       this.props.dispatch(PagesModelActions.addPage({ url }));
@@ -63,6 +63,6 @@ export default class Window extends PureComponent {
 }
 
 Window.WrappedComponent.propTypes = {
-  // client: SharedPropTypes.Client.isRequired,
+  client: SharedPropTypes.Client.isRequired,
   dispatch: PropTypes.func.isRequired,
 };

--- a/src/browser-frontend/views/browser/window.jsx
+++ b/src/browser-frontend/views/browser/window.jsx
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
 import Mousetrap from 'mousetrap';
 
 import { client } from '../../global';
-import PagesModelActions from '../../actions/pages-model-actions';
+import KeyboardShortcutsActions from '../../actions/keyboard-shortcuts-actions';
 import * as SharedPropTypes from '../../model/shared-prop-types';
 import SharedActions from '../../../shared/actions/shared-actions';
 
@@ -35,20 +35,31 @@ export default class Window extends PureComponent {
     // Some keyboard shortcuts need to be registered at the platform level,
     // because they clash with OS-level shortcuts (e.g. Cmd+W on macOS
     // hides windows, but we want it to close tabs instead.). The platform
-    // is tasked with overriding these shortcuts and providing us control.
+    // is responsible with overriding these shortcuts and providing us control.
     this.props.client.send(SharedActions.commands.fromFrontend.toServer.app.window.keyShortcuts.register([
       { keys: 'CommandOrControl+Q' },
       { keys: 'CommandOrControl+W' },
     ]));
 
     // For everything else, listening to key events in the frontend is fine.
+    // We should listen to the above "special" key events normally too, so that
+    // all shortcuts work headless as well (when opening the frontend in a tab).
     this.mousetrap = Mousetrap();
-    this.mousetrap.bind('mod+t', () => {
-      this.props.dispatch(PagesModelActions.addPage());
+    this.mousetrap.bind('mod+q', (e) => {
+      e.preventDefault();
+      this.props.dispatch(KeyboardShortcutsActions.pressedAccelQ());
     });
-    this.mousetrap.bind('up up down down left right left right b a', () => {
-      const url = 'http://chilloutandwatchsomecatgifs.com/';
-      this.props.dispatch(PagesModelActions.addPage({ url }));
+    this.mousetrap.bind('mod+w', (e) => {
+      e.preventDefault();
+      this.props.dispatch(KeyboardShortcutsActions.pressedAccelW());
+    });
+    this.mousetrap.bind('mod+t', (e) => {
+      e.preventDefault();
+      this.props.dispatch(KeyboardShortcutsActions.pressedAccelT());
+    });
+    this.mousetrap.bind('up up down down left right left right b a', (e) => {
+      e.preventDefault();
+      this.props.dispatch(KeyboardShortcutsActions.pressedCatGifsEasterEgg());
     });
   }
 

--- a/src/browser-runner/platform-electron/sagas/server-command-handlers.js
+++ b/src/browser-runner/platform-electron/sagas/server-command-handlers.js
@@ -79,7 +79,7 @@ function* openDevTools({ meta: client, payload: { winId, detach } }) {
   yield call([client, client.send], SharedActions.events.fromRunner.toServer.app.window.devtools.closed({ winId }));
 }
 
-function* registerKeyShortcuts({ meta: client, payload: { winId, shortcuts, ...args } }) {
+function* registerKeyShortcuts({ meta: client, payload: { winId, shortcuts } }) {
   const win = BROWSER_WINDOWS.get(winId);
   if (!win) {
     throw new Error(`Unknown browser window: ${winId}.`);
@@ -87,8 +87,8 @@ function* registerKeyShortcuts({ meta: client, payload: { winId, shortcuts, ...a
 
   const listener = (shortcut) => {
     client.send(SharedActions.events.fromRunner.toServer.app.window.keyShortcuts.pressed({
+      winId,
       shortcut,
-      ...args,
     }));
   };
 

--- a/src/browser-server/connection.js
+++ b/src/browser-server/connection.js
@@ -14,14 +14,14 @@ import colors from 'colour';
 import { createAction } from 'redux-actions';
 
 export default class Connection {
-  static _instances = new Map()
+  static _instancesByConnId = new Map()
 
   constructor({ server, pipe, store, logger }) {
     this._server = server;
     this._pipe = pipe;
     this._store = store;
     this._logger = logger;
-    Connection._instances.set(this.id, this);
+    Connection._instancesByConnId.set(this.id, this);
   }
 
   listen() {
@@ -43,6 +43,6 @@ export default class Connection {
   }
 
   static getWithId(id) {
-    return Connection._instances.get(id);
+    return Connection._instancesByConnId.get(id);
   }
 }

--- a/src/browser-server/frontend-connection.js
+++ b/src/browser-server/frontend-connection.js
@@ -1,0 +1,43 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import isUUID from 'is-uuid';
+
+import Connection from './connection';
+
+export default class FrontendConnection extends Connection {
+  static _instancesByWinId = new Map()
+
+  constructor(...args) {
+    super(...args);
+  }
+
+  send(...args) {
+    if (!isUUID.v4(this._frontendWinId)) {
+      throw new Error('No associated frontend window for this connection.');
+    }
+    return super.send(...args);
+  }
+
+  setFrontendWinId(winId) {
+    this._frontendWinId = winId;
+    FrontendConnection._instancesByWinId.set(winId, this);
+  }
+
+  get frontendWinId() {
+    return this._frontendWinId;
+  }
+
+  static getWithFrontendWinId(winId) {
+    return FrontendConnection._instancesByWinId.get(winId);
+  }
+}

--- a/src/browser-server/sagas/frontend-command-handlers.js
+++ b/src/browser-server/sagas/frontend-command-handlers.js
@@ -1,0 +1,37 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import { takeEvery, call, select } from 'redux-saga/effects';
+
+import Connection from '../connection';
+import SharedActions from '../../shared/actions/shared-actions';
+import * as FrontendConnectionsSelectors from '../selectors/frontend-connections-selectors';
+
+function* registerKeyShortcuts({ meta: frontendConn, payload: shortcuts }) {
+  const frontendConnId = frontendConn.id;
+  const { runnerConnId, winId } = yield select(FrontendConnectionsSelectors.getFrontendClientMetaData, frontendConnId);
+
+  const action = SharedActions.commands.fromServer.toRunner.app.window.keyShortcuts.register({
+    winId,
+    shortcuts,
+    info: { frontendConnId },
+  });
+
+  const runnerConn = Connection.getWithId(runnerConnId);
+  yield call([runnerConn, runnerConn.send], action);
+}
+
+export default function* () {
+  yield [
+    takeEvery(SharedActions.commands.fromFrontend.toServer.app.window.keyShortcuts.register, registerKeyShortcuts),
+  ];
+}

--- a/src/browser-server/sagas/frontend-command-handlers.js
+++ b/src/browser-server/sagas/frontend-command-handlers.js
@@ -23,7 +23,6 @@ function* registerKeyShortcuts({ meta: frontendConn, payload: shortcuts }) {
   const action = SharedActions.commands.fromServer.toRunner.app.window.keyShortcuts.register({
     winId,
     shortcuts,
-    info: { frontendConnId },
   });
 
   const runnerConn = Connection.getWithId(runnerConnId);

--- a/src/browser-server/sagas/frontend-event-handlers.js
+++ b/src/browser-server/sagas/frontend-event-handlers.js
@@ -46,11 +46,20 @@ function* onRequestedMaximizeWindow({ meta: frontendConn }) {
   yield call([runnerConn, runnerConn.send], SharedActions.commands.fromServer.toRunner.app.window.maximize({ winId }));
 }
 
+function* onRequestedQuit({ meta: frontendConn }) {
+  const frontendConnId = frontendConn.id;
+  const { runnerConnId } = yield select(FrontendConnectionsSelectors.getFrontendClientMetaData, frontendConnId);
+
+  const runnerConn = Connection.getWithId(runnerConnId);
+  yield call([runnerConn, runnerConn.send], SharedActions.commands.fromServer.toRunner.platform.quit());
+}
+
 export default function* () {
   yield [
     takeEvery(SharedActions.events.fromFrontend.toServer.client.hello, onClientHello),
     takeEvery(SharedActions.events.fromFrontend.toServer.app.window.requestedClose, onRequestedCloseWindow),
     takeEvery(SharedActions.events.fromFrontend.toServer.app.window.requestedMinimize, onRequestedMinimizeWindow),
     takeEvery(SharedActions.events.fromFrontend.toServer.app.window.requestedMaximize, onRequestedMaximizeWindow),
+    takeEvery(SharedActions.events.fromFrontend.toServer.app.window.requestedQuit, onRequestedQuit),
   ];
 }

--- a/src/browser-server/sagas/frontend-event-handlers.js
+++ b/src/browser-server/sagas/frontend-event-handlers.js
@@ -20,6 +20,10 @@ import * as FrontendConnectionsSelectors from '../selectors/frontend-connections
 function* onClientHello({ meta: frontendConn, payload: { clientMetaData } }) {
   const frontendConnId = frontendConn.id;
   yield put(FrontendConnectionsModelActions.addFrontendConnection({ frontendConnId, clientMetaData }));
+
+  // Allow identifying and finding this connection by the frontend window id,
+  // not just the websocket connection's id.
+  frontendConn.setFrontendWinId(clientMetaData.winId);
 }
 
 function* onRequestedCloseWindow({ meta: frontendConn }) {

--- a/src/browser-server/sagas/helpers.js
+++ b/src/browser-server/sagas/helpers.js
@@ -1,0 +1,37 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import { call, select } from 'redux-saga/effects';
+import querystring from 'querystring';
+import uuid from 'uuid/v4';
+
+import { CHROME_URL } from '../constants/endpoints';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../constants/browser-window-defaults';
+
+import SharedActions from '../../shared/actions/shared-actions';
+import * as RunnerConnectionsSelectors from '../selectors/runner-connections-selectors';
+
+export function* createWindow({ meta: runnerConn }) {
+  const runnerConnId = runnerConn.id;
+  const { os, platform } = yield select(RunnerConnectionsSelectors.getRunnerClientMetaData, runnerConnId);
+
+  const winId = uuid();
+  const frontendParams = querystring.stringify({ runnerConnId, winId, os, platform });
+
+  yield call([runnerConn, runnerConn.send], SharedActions.commands.fromServer.toRunner.app.window.create({
+    winId,
+    url: `${CHROME_URL}?${frontendParams}`,
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+    style: os === 'darwin' ? 'onlyTitleBarHiddenAndWindowControlsInset' : 'chromeless',
+  }));
+}

--- a/src/browser-server/sagas/root-saga.js
+++ b/src/browser-server/sagas/root-saga.js
@@ -12,10 +12,12 @@ specific language governing permissions and limitations under the License.
 
 import runnerEventHandlers from './runner-event-handlers';
 import frontendEventHandlers from './frontend-event-handlers';
+import frontendCommandHandlers from './frontend-command-handlers';
 
 export default function* () {
   yield [
     runnerEventHandlers(),
     frontendEventHandlers(),
+    frontendCommandHandlers(),
   ];
 }

--- a/src/browser-server/sagas/runner-event-handlers.js
+++ b/src/browser-server/sagas/runner-event-handlers.js
@@ -13,6 +13,7 @@ specific language governing permissions and limitations under the License.
 import { takeEvery, call, put, select } from 'redux-saga/effects';
 
 import * as Helpers from './helpers';
+import Connection from '../connection';
 import SharedActions from '../../shared/actions/shared-actions';
 import RunnerConnectionsModelActions from '../actions/runner-connections-model-actions';
 import WindowsModelActions from '../actions/windows-model-actions';
@@ -71,6 +72,14 @@ function* onDevToolsClosed({ meta: runnerConn, payload: { winId } }) {
   yield put(WindowsModelActions.window.setDevToolsClosed({ runnerConnId, winId }));
 }
 
+function* onKeyShortcutPressed({ payload: { shortcut, info } }) {
+  const frontendConnId = info.frontendConnId;
+  const frontendConn = Connection.getWithId(frontendConnId);
+
+  const action = SharedActions.events.fromServer.toFrontend.app.window.keyShortcuts.pressed({ shortcut });
+  yield call([frontendConn, frontendConn.send], action);
+}
+
 export default function* () {
   yield [
     takeEvery(SharedActions.events.fromRunner.toServer.client.hello, onClientHello),
@@ -79,5 +88,6 @@ export default function* () {
     takeEvery(SharedActions.events.fromRunner.toServer.app.window.closed, onWindowClosed),
     takeEvery(SharedActions.events.fromRunner.toServer.app.window.devtools.opened, onDevToolsOpened),
     takeEvery(SharedActions.events.fromRunner.toServer.app.window.devtools.closed, onDevToolsClosed),
+    takeEvery(SharedActions.events.fromRunner.toServer.app.window.keyShortcuts.pressed, onKeyShortcutPressed),
   ];
 }

--- a/src/browser-server/sagas/runner-event-handlers.js
+++ b/src/browser-server/sagas/runner-event-handlers.js
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 import { takeEvery, call, put, select } from 'redux-saga/effects';
 
 import * as Helpers from './helpers';
-import Connection from '../connection';
+import FrontendConnection from '../frontend-connection';
 import SharedActions from '../../shared/actions/shared-actions';
 import RunnerConnectionsModelActions from '../actions/runner-connections-model-actions';
 import WindowsModelActions from '../actions/windows-model-actions';
@@ -72,9 +72,8 @@ function* onDevToolsClosed({ meta: runnerConn, payload: { winId } }) {
   yield put(WindowsModelActions.window.setDevToolsClosed({ runnerConnId, winId }));
 }
 
-function* onKeyShortcutPressed({ payload: { shortcut, info } }) {
-  const frontendConnId = info.frontendConnId;
-  const frontendConn = Connection.getWithId(frontendConnId);
+function* onKeyShortcutPressed({ payload: { winId, shortcut } }) {
+  const frontendConn = FrontendConnection.getWithFrontendWinId(winId);
 
   const action = SharedActions.events.fromServer.toFrontend.app.window.keyShortcuts.pressed({ shortcut });
   yield call([frontendConn, frontendConn.send], action);

--- a/src/browser-server/ws/browser-frontend.js
+++ b/src/browser-server/ws/browser-frontend.js
@@ -14,7 +14,7 @@ import colors from 'colour';
 
 import logger from '../logger';
 
-import Connection from '../connection';
+import FrontendConnection from '../frontend-connection';
 import FrontendConnectionsModelActions from '../actions/frontend-connections-model-actions';
 
 async function onConnectionClosed(store, conn) {
@@ -23,7 +23,7 @@ async function onConnectionClosed(store, conn) {
 }
 
 async function onConnectionEstablished(wss, ws, store) {
-  const conn = new Connection({ server: wss, pipe: ws, store, logger });
+  const conn = new FrontendConnection({ server: wss, pipe: ws, store, logger });
   await conn.listen();
 
   logger.log(colors.green(`WebSocket connection to browser frontend established: ${conn.id}.`));

--- a/src/shared/actions/shared-actions.js
+++ b/src/shared/actions/shared-actions.js
@@ -29,6 +29,20 @@ export default createActions({
               OPENED: identity,
               CLOSED: identity,
             },
+            KEY_SHORTCUTS: {
+              PRESSED: identity,
+            },
+          },
+        },
+      },
+    },
+    FROM_SERVER: {
+      TO_FRONTEND: {
+        APP: {
+          WINDOW: {
+            KEY_SHORTCUTS: {
+              PRESSED: identity,
+            },
           },
         },
       },
@@ -43,6 +57,7 @@ export default createActions({
             REQUESTED_MINIMIZE: identity,
             REQUESTED_MAXIMIZE: identity,
             REQUESTED_CLOSE: identity,
+            REQUESTED_QUIT: identity,
           },
         },
       },
@@ -60,10 +75,24 @@ export default createActions({
             DEVTOOLS: {
               OPEN: identity,
             },
+            KEY_SHORTCUTS: {
+              REGISTER: identity,
+            },
           },
         },
         PLATFORM: {
           QUIT: identity,
+        },
+      },
+    },
+    FROM_FRONTEND: {
+      TO_SERVER: {
+        APP: {
+          WINDOW: {
+            KEY_SHORTCUTS: {
+              REGISTER: identity,
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
tl;dr: We can't handle some keyboard shortcuts in frontends. We need some amount of platform support to overwrite OS-level shortcuts like Cmd+W on macOS. And down the rabbit hole we go.

Problem statement:
We'd like to have some keyboard shortcuts. Registering them in the frontend is preferable simply due to convenience. It's easy to listen to key events and do things in the event listeners.

Solutions:
1. A naive approach would register all keyboard shortcuts in the frontend alone. This cannot work in all cases though, since we can't alter platform-specific behavior (like Cmd+W hiding windows on macOS, while we want it to close tabs instead; maybe we'll even decide to do something different on Cmd+Q or Alt+F4, who knows).

2. Another approach would be (1), plus a simple fix to the problem described above, where windows are prevented from closing unless specifically directed by the frontend. On the surface, this works fine, since we draw our own window controls (close button etc.) and can instruct the browser runner platform to quit from the frontend itself. This cannot scale, however, since the frontend isn't the only responsible entity for closing the window. (Ctrl+C in a terminal should work, we can't allow that to happen while still preventing windows to close generally; Additionally, maybe we want to draw native window controls on some operating systems). There aren't any good solutions to handling this problem, and once you add other behaviors in the mix (suppose we'd like to override Cmd+M for custom actions instead of minimizing windows, for example, similarly to how Cmd+W doesn't hide windows, but performs the custom action of closing a tab), possible implementations (if they even exist) rapidly increase in complexity. This was the solution implemented in #51 

3. Yet another approach would be (1), plus a subtly different take on (2): instead of preventing windows from closing, eat the overridden keyboard shortcuts themselves on the platform-side. In theory this would allow custom behavior on Cmd+W, for example, when defined in the frontend, while the platform would prevent the default OS-level action of hiding a window. In practice this doesn't work, as frontends would not receive those key combos at all if they're eaten at the platform level.

4. Accept the reality that overriding os-defined keyboard shortcuts requires platform support, and adjust accordingly. 

This PR implements (4). Generally it's expected that most keyboard shortcuts can be implemented by simply listening to key events in the frontend. However, in some cases we simply cannot rely on this to work cross operating systems (e.g. Cmd+W), so provide a means of registering shortcuts through browser runners, but still handle them in the frontend. Therefore the proposed solution is a mixed approach.

A possible emerging advantage from (4) is that we're not forced to perform the actions we want (based on what keyboard shortcuts are pressed) in the same process in which they're registered, so we're not constrained nor concerned with having to sync or share application state between components/processes. Registering keyboard shortcuts is a notification-like service provided by browser runners, which you can use if you want to.

I'd also be happy if we're to decide we want all shortcuts to be handled through the browser runner completely, not just Cmd+W and the likes. However, this necessarily requires that all browser runner implementations accept keyboard shortcut registering commands, which makes it a bit developer unfriendly to get one such implementation quickly running off the ground. For example, if we're to go this route, our qbrt runner will never have any keyboard shortcuts unless we explicitly add support for it. With the mixed approach suggested in this PR, Cmd+W hides windows instead of closing tabs in qbrt, but at least everything else does work.