### PR TITLE
bump neon-mentat

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "less": "2.7.2",
     "lodash": "4.17.4",
     "morgan": "1.8.1",
-    "neon-mentat": "github:bgrins/neon-mentat#1b03721",
+    "neon-mentat": "github:bgrins/neon-mentat#e01b413",
     "mousetrap": "1.6.1",
     "opn": "4.0.2",
     "portastic": "1.0.1",

--- a/src/browser-server/test/test-mentat.js
+++ b/src/browser-server/test/test-mentat.js
@@ -31,7 +31,7 @@ describe('mentat', () => {
     const input = `[:find ?e
                 :where
                 [?e :movie/title "Die Hard" _]]`;
-    const result = MentatConnection.query(input);
-    expect(result.resultsLength).toEqual(1);
+    const response = MentatConnection.query(input);
+    expect(response.results.length).toEqual(1);
   });
 });


### PR DESCRIPTION
This version adds supports for Scalars and gets rid of `resultsLength` since results will always be an array for queries, and we can do `results.length` instead